### PR TITLE
Update install_ansible_in_Vagrantbox.sh

### DIFF
--- a/ansible/tools/install_ansible_in_Vagrantbox.sh
+++ b/ansible/tools/install_ansible_in_Vagrantbox.sh
@@ -10,8 +10,7 @@ if [ "$ansible_installed" -eq 0 ]; then
   fi
 
   # Add ansible 2.6 repository and install ansible
-  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-  echo "deb http://ppa.launchpad.net/ansible/ansible-2.6/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/ansible.list
+  sudo add-apt-repository ppa:ansible/ansible-2.6
   sudo apt update -y
   sudo apt install -y ansible
 


### PR DESCRIPTION
I was getting an error during the update process due to wrong GPG key

Replaced the way the key has been added with `sudo add-apt-repository ppa:ansible/ansible-2.6` so now it's working.

```TASK [updates : Install aptitude and needrestart] ******************************
failed: [default] (item=[u'aptitude', u'needrestart']) => {"failed": true, "item": ["aptitude", "needrestart"], "msg": "Failed to update apt cache."}
	to retry, use: --limit @/vagrant/ansible/playbook.retry
PLAY RECAP *********************************************************************
default                    : ok=7    changed=4    unreachable=0    failed=1
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.```